### PR TITLE
chore: openclaw control live canary

### DIFF
--- a/.github/workflows/openclaw-control-canary.yml
+++ b/.github/workflows/openclaw-control-canary.yml
@@ -1,0 +1,13 @@
+name: OpenClaw Control Canary
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/openclaw-control-canary.yml"
+      - "ops/openclaw-control-github-canary-20260421.md"
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "openclaw control canary ok"

--- a/ops/openclaw-control-github-canary-20260421.md
+++ b/ops/openclaw-control-github-canary-20260421.md
@@ -1,0 +1,3 @@
+# OpenClaw Control GitHub Canary
+
+This draft PR exists only to verify the live branch, PR, and CI path for the OpenClaw control-plane rollout.


### PR DESCRIPTION
This draft PR is a live canary for the OpenClaw control-plane rollout.

Purpose:
- verify real branch -> PR -> CI path
- keep the change isolated and harmless
- avoid touching production behavior

Files:
- .github/workflows/openclaw-control-canary.yml
- ops/openclaw-control-github-canary-20260421.md