### PR TITLE
docs: clarify claude runner backend modes

### DIFF
--- a/docs-site/docs/setup-guide/claude-code.md
+++ b/docs-site/docs/setup-guide/claude-code.md
@@ -58,16 +58,20 @@ claude
 
 ---
 
-## Использование Ollama-моделей с VPS (экономия токенов)
+## Использование кастомного backend для Claude Code
 
-По умолчанию Claude Code использует Anthropic API. Можно переключиться на модели Ollama на VPS.
+По умолчанию Claude Code использует Anthropic API. Это и есть основной production-путь.
+
+Если нужен `Kimi/GLM` или другой не-Claude backend, нужен отдельный Anthropic-compatible bridge. Напрямую в raw Ollama Claude Code отправлять нельзя.
 
 ### Алиасы в ~/.zshrc
 
 ```bash
-# Claude Code → Ollama на VPS (через litellm прокси)
-alias cc-local='ANTHROPIC_BASE_URL=http://YOUR_VPS_IP:8082 ANTHROPIC_API_KEY=ollama claude'
-alias cc-cloud='unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY && claude'
+# Claude Code → стандартный Anthropic backend
+alias cc-native='unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY && claude'
+
+# Claude Code → кастомный Anthropic-compatible bridge
+alias cc-bridge='ANTHROPIC_BASE_URL=http://YOUR_BRIDGE_HOST:PORT ANTHROPIC_API_KEY=bridge-token claude'
 
 # Codex → Ollama напрямую (через SSH-туннель)
 alias cx-light='OPENAI_BASE_URL=http://localhost:11434/v1 OPENAI_API_KEY=ollama codex -m qwen3:8b'
@@ -76,22 +80,20 @@ alias cx-medium='OPENAI_BASE_URL=http://localhost:11434/v1 OPENAI_API_KEY=ollama
 
 Использование:
 ```bash
-cc-local   # Claude Code → qwen3/glm-5 через VPS
-cc-cloud   # Claude Code → стандартный Anthropic API
+cc-native  # Claude Code → стандартный Anthropic API
+cc-bridge  # Claude Code → bridge для Kimi/GLM
 cx-light   # Codex → qwen3:8b (лёгкие задачи)
 ```
 
-### Что нужно на VPS
+### Что нужно для Kimi/GLM
 
-**litellm** — прокси, переводящий формат Anthropic → OpenAI (для Ollama):
+Нужен отдельный bridge, который:
 
-```bash
-# Уже настроен как systemd-служба: ai-office/vps/systemd/litellm.service
-systemctl status litellm   # проверить
-systemctl start litellm    # запустить если не работает
-```
+- принимает Anthropic-compatible запросы от Claude Code
+- сам маршрутизирует их в целевой backend
+- корректно поддерживает tool-use flow
 
-Слушает на порту 8082.
+Пока такого bridge нет, production-путь для Claude runner — native Claude backend.
 
 ### SSH-туннель для Codex (Ollama на порту 11434)
 

--- a/future-compat.md
+++ b/future-compat.md
@@ -1,8 +1,14 @@
 # Future Compatibility Notes
 
+## Claude Runner: Backend Modes
+
+**Production default:** Claude Code CLI uses the native Anthropic backend. This is the only zero-config production path.
+
+**Alternative backends such as Kimi or GLM:** Claude Code cannot talk to them directly. They require an explicit Anthropic-compatible bridge and must not be treated as zero-config.
+
 ## Claude Code CLI → Ollama Backend
 
-Claude Code CLI uses the Anthropic SDK. To redirect it to a local/custom backend:
+Claude Code CLI uses the Anthropic SDK. To redirect it to a local/custom backend, put a bridge in front of the target model backend:
 
 ```bash
 # Point Claude Code at Ollama's OpenAI-compatible endpoint
@@ -16,7 +22,7 @@ export ANTHROPIC_API_KEY=ollama   # dummy key, ollama ignores it
 **Caveat:** Claude Code expects Claude-specific response formats (tool_use, thinking blocks).
 Ollama models respond in OpenAI format. Full compatibility requires a proxy layer.
 
-**Recommended proxy:** `litellm` — translates between Anthropic and OpenAI formats:
+**Required bridge example:** `litellm` translates between Anthropic and OpenAI formats:
 ```bash
 pip install litellm
 litellm --model ollama/glm-5:cloud --port 8082 --drop_params
@@ -46,7 +52,7 @@ Docs: https://github.com/openai/codex
 
 | Tool | Best for | Model |
 |------|---------|-------|
-| Claude Code CLI | Complex multi-file coding, planning | Needs Claude-format proxy |
+| Claude Code CLI | Complex multi-file coding, planning | Native Claude by default; custom backends need a Claude-format bridge |
 | Codex CLI | Single-shot code gen, scripts | Direct ollama compat |
 | OpenClaw agent | Telegram interactions, research, automation | glm-5:cloud / minimax-m2:cloud |
 


### PR DESCRIPTION
OpenClaw canary task: clarify Claude runner backend modes in documentation.

- native Claude backend is the default production path
- Kimi/GLM require an explicit Anthropic-compatible bridge
- wording updated in future-compat and Claude Code setup docs